### PR TITLE
Fixes get_query_set deprecation warning in Django 1.7.

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -258,7 +258,7 @@ class PassThroughManagerMixin(object):
         self._queryset_cls is None.
         """
         my_values = frozenset(dir(type(self)))
-        my_values |= frozenset(dir(self.get_query_set()))
+        my_values |= frozenset(dir(self.get_queryset()))
         return list(my_values)
 
     def get_queryset(self):


### PR DESCRIPTION
Hi there, this should fix a deprecation warning when using `PassThroughManager` in Django 1.7.
