### PR TITLE
Use shields.io for PyPI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ django-model-utils
    :target: http://travis-ci.org/carljm/django-model-utils
 .. image:: https://coveralls.io/repos/carljm/django-model-utils/badge.png?branch=master
    :target: https://coveralls.io/r/carljm/django-model-utils
-.. image:: https://pypip.in/v/django-model-utils/badge.png
+.. image:: https://img.shields.io/pypi/v/django-model-utils.svg
    :target: https://crate.io/packages/django-model-utils
 
 Django model mixins and utilities.


### PR DESCRIPTION
pypipins is down: badges/pypipins#37

shields.io seems to be fairly stable.

Some other fun badges:

![python
versions](https://img.shields.io/pypi/pyversions/django-model-utils.svg)
![license](https://img.shields.io/badge/license-New%20BSD-blue.svg)
![stability](https://img.shields.io/pypi/status/django-model-utils.svg)
![issue
count](https://img.shields.io/github/issues/carljm/django-model-utils.svg)