### PR TITLE
New PersistentMonitorField type

### DIFF
--- a/model_utils/tests/models.py
+++ b/model_utils/tests/models.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel, StatusModel, TimeFramedModel
 from model_utils.tracker import FieldTracker, ModelTracker
 from model_utils.managers import QueryManager, InheritanceManager, PassThroughManager
-from model_utils.fields import SplitField, MonitorField, StatusField
+from model_utils.fields import SplitField, MonitorField, StatusField, PersistentMonitorField
 from model_utils.tests.fields import MutableField
 from model_utils import Choices
 
@@ -98,6 +98,24 @@ class MonitorWhen(models.Model):
 class MonitorWhenEmpty(models.Model):
     name = models.CharField(max_length=25)
     name_changed = MonitorField(monitor="name", when=[])
+
+
+
+class PersistentMonitored(models.Model):
+    name = models.CharField(max_length=25)
+    name_changed = PersistentMonitorField(monitor="name")
+
+
+
+class PersistentMonitorWhen(models.Model):
+    name = models.CharField(max_length=25)
+    name_changed = PersistentMonitorField(monitor="name", when=["Jose", "Maria"])
+
+
+
+class PersistentMonitorWhenEmpty(models.Model):
+    name = models.CharField(max_length=25)
+    name_changed = PersistentMonitorField(monitor="name", when=[])
 
 
 


### PR DESCRIPTION
Hi there. I've found this useful in my code and thought you might want to merge it into the main codebase so it can be used by others

- Same as a MonitorField except once a timestamp is recorded on field change, it is never recorded again for any other change
- Useful if you only ever want the timestamp to be set on the first change