### PR TITLE
Backwards compatibility issue: fix _clone signature for Django<1.9

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,4 +35,5 @@ sayane
 Tony Aldridge <zaragopha@hotmail.com>
 Travis Swicegood <travis@domain51.com>
 Trey Hunner <trey@treyhunner.com>
+Karl Wan Nan Wo <karl.wnw@gmail.com>
 zyegfryed

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -53,10 +53,13 @@ class InheritanceQuerySetMixin(object):
         new_qs.subclasses = subclasses
         return new_qs
 
-    def _clone(self, **kwargs):
+    def _clone(self, klass=None, setup=False, **kwargs):
         for name in ['subclasses', '_annotated']:
             if hasattr(self, name):
                 kwargs[name] = getattr(self, name)
+        if django.VERSION < (1, 9):
+            kwargs['klass'] = klass
+            kwargs['setup'] = setup
         return super(InheritanceQuerySetMixin, self)._clone(**kwargs)
 
     def annotate(self, *args, **kwargs):

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -763,6 +763,11 @@ class InheritanceManagerTests(TestCase):
                          set(expected_related_names))
 
 
+    def test_filter_on_values_queryset(self):
+        queryset = InheritanceManagerTestChild1.objects.values('id').filter(pk=self.child1.pk)
+        self.assertEqual(list(queryset), [{'id': self.child1.pk}])
+
+
 class InheritanceManagerUsingModelsTests(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Model example:

```python
class Place(models.Model):
    objects = InheritanceManager()
    name = models.CharField(max_length=64, null=True, blank=True)
```

`Place.objects.values('id').filter(name='Somewhere')`

```python
----> 1 Place.objects.values('id').filter(name='Somewhere')

/django/db/models/query.pyc in filter(self, *args, **kwargs)
    677         set.
    678         """
--> 679         return self._filter_or_exclude(False, *args, **kwargs)
    680
    681     def exclude(self, *args, **kwargs):

/django/db/models/query.pyc in _filter_or_exclude(self, negate, *args, **kwargs)
    691                 "Cannot filter a query once a slice has been taken."
    692
--> 693         clone = self._clone()
    694         if negate:
    695             clone.query.add_q(~Q(*args, **kwargs))

/django/db/models/query.pyc in _clone(self, klass, setup, **kwargs)
   1142         Cloning a ValuesQuerySet preserves the current fields.
   1143         """
-> 1144         c = super(ValuesQuerySet, self)._clone(klass, **kwargs)
   1145         if not hasattr(c, '_fields'):
   1146             # Only clone self._fields if _fields wasn't passed into the cloning

TypeError: _clone() takes exactly 1 argument (2 given)
```
InheritanceQuerySetMixin._clone signature conflicts with django (<1.9)
ValuesQuerySet._clone code which calls super like this:
"c = super(ValuesQuerySet, self)._clone(klass, **kwargs)"