### PR TITLE
Fixes AttributeError - ModelChoiceField requires _prefetch_related_lookups attribute

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -175,6 +175,7 @@ class InheritanceQuerySetMixin(object):
 
 
 class InheritanceManagerMixin(object):
+    _prefetch_related_lookups = []
     use_for_related_fields = True
 
     def get_queryset(self):

--- a/model_utils/tests/forms.py
+++ b/model_utils/tests/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+
+class ModelChoiceForm(forms.Form):
+    items = forms.ModelChoiceField(queryset=None, empty_label=None)
+
+    def __init__(self, queryset, *args, **kwargs):
+        super(ModelChoiceForm, self).__init__(*args, **kwargs)
+        self.fields['items'].queryset = queryset

--- a/model_utils/tests/models.py
+++ b/model_utils/tests/models.py
@@ -29,7 +29,7 @@ class InheritanceManagerTestParent(models.Model):
     objects = InheritanceManager()
 
     def __unicode__(self):
-        return unicode(self.pk)
+        return self.pk
 
     def __str__(self):
         return "%s(%s)" % (

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -1831,5 +1831,5 @@ class InheritanceManagerFormTests(TestCase):
     def test_form_field_return_all_items(self):
         form = ModelChoiceForm(
             queryset=InheritanceManagerTestParent.objects)
-        choices = [item[0] for item in form.fields['items'].choices]
+        choices = [item for item in form.fields['items'].choices]
         self.assertEqual(len(choices), 3)

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -1828,8 +1828,10 @@ class InheritanceManagerFormTests(TestCase):
         self.child2 = InheritanceManagerTestChild2.objects.create()
         self.grandchild1 = InheritanceManagerTestGrandChild1.objects.create()
 
+    def get_manager(self):
+        return InheritanceManagerTestParent.objects
+
     def test_form_field_return_all_items(self):
-        form = ModelChoiceForm(
-            queryset=InheritanceManagerTestParent.objects)
+        form = ModelChoiceForm(queryset=self.get_manager())
         choices = [item for item in form.fields['items'].choices]
         self.assertEqual(len(choices), 3)

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -1831,5 +1831,5 @@ class InheritanceManagerFormTests(TestCase):
     def test_form_field_return_all_items(self):
         form = ModelChoiceForm(
             queryset=InheritanceManagerTestParent.objects)
-        choices = [item for item in form.fields['items'].choices]
+        choices = [item[0] for item in form.fields['items'].choices]
         self.assertEqual(len(choices), 3)

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -18,6 +18,7 @@ from model_utils import Choices, FieldTracker
 from model_utils.fields import get_excerpt, MonitorField, StatusField
 from model_utils.managers import QueryManager
 from model_utils.models import StatusModel, TimeFramedModel
+from model_utils.tests.forms import ModelChoiceForm
 from model_utils.tests.models import (
     InheritanceManagerTestRelated, InheritanceManagerTestGrandChild1,
     InheritanceManagerTestGrandChild1_2,
@@ -1818,3 +1819,17 @@ class InheritedModelTrackerTests(ModelTrackerTests):
         self.name2 = 'test'
         self.assertEqual(self.tracker.previous('name2'), None)
         self.assertTrue(self.tracker.has_changed('name2'))
+
+
+class InheritanceManagerFormTests(TestCase):
+
+    def setUp(self):
+        self.child1 = InheritanceManagerTestChild1.objects.create()
+        self.child2 = InheritanceManagerTestChild2.objects.create()
+        self.grandchild1 = InheritanceManagerTestGrandChild1.objects.create()
+
+    def test_form_field_return_all_items(self):
+        form = ModelChoiceForm(
+            queryset=InheritanceManagerTestParent.objects)
+        choices = [item for item in form.fields['items'].choices]
+        self.assertEqual(len(choices), 3)

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     django15{,_nosouth}: Django==1.5.12
     django16: Django==1.6.10
     django17: Django==1.7.7
-    django18: Django==1.8.5
+    django18: Django==1.8.6
     django19: Django==1.9b1
     django_trunk: https://github.com/django/django/tarball/master
     django{14,15,16}: South==1.0.2


### PR DESCRIPTION
This PR fixes the following error in the latest stable version of Django (`1.8.6`):
```
(...)/site-packages/django/forms/models.py", line 1095, in __iter__
    method = 'all' if self.queryset._prefetch_related_lookups else 'iterator'
AttributeError: 'InheritanceManager' object has no attribute '_prefetch_related_lookups'
```
`ModelChoiceField` requires  [_prefetch_related_lookups](https://github.com/django/django/pull/5397/files#diff-70af885c2725fe87eb3b99a393268d10R1106) queryset attribute. 