### PR TITLE
Start testing against Django 1.9 stable

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py26-django{14,15,16},
     py27-django14, py27-django15_nosouth,
     py{27,32,33}-django{15,16,17,18,_trunk},
+    py27-django19,
     py34-django{17,18,19,_trunk},
 
 [testenv]
@@ -20,7 +21,7 @@ deps =
     django16: Django==1.6.10
     django17: Django==1.7.7
     django18: Django==1.8.5
-    django19: Django==1.9b1
+    django19: Django==1.9
     django_trunk: https://github.com/django/django/tarball/master
     django{14,15,16}: South==1.0.2
 


### PR DESCRIPTION
A release that supports 1.9 would be nice.