### PR TITLE
Django bug has been fixed

### DIFF
--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -84,14 +84,8 @@ If you don't explicitly call ``select_subclasses()`` or ``get_subclass()``,
 an ``InheritanceManager`` behaves identically to a normal ``Manager``; so
 it's safe to use as your default manager for the model.
 
-.. note::
-
-    Due to `Django bug #16572`_, on Django versions prior to 1.6
-    ``InheritanceManager`` only supports a single level of model inheritance;
-    it won't work for grandchild models.
 
 .. _contributed by Jeff Elmore: http://jeffelmore.org/2010/11/11/automatic-downcasting-of-inherited-models-in-django/
-.. _Django bug #16572: https://code.djangoproject.com/ticket/16572
 
 
 .. _QueryManager:


### PR DESCRIPTION
The Django bug mentioned by this comment was fixed 3 years ago. I haven't double checked that InheritanceManager now behaves correctly in that use case, but the note at least is invalid.
