### PR TITLE
Drop unsupported Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,30 +3,18 @@ language: python
 python: 2.7
 
 env:
-  - TOXENV=py26-django14
-  - TOXENV=py26-django15
-  - TOXENV=py26-django16
-  - TOXENV=py27-django110
-  - TOXENV=py27-django14
-  - TOXENV=py27-django15
-  - TOXENV=py27-django15_nosouth
-  - TOXENV=py27-django16
-  - TOXENV=py27-django17
   - TOXENV=py27-django18
   - TOXENV=py27-django19
+  - TOXENV=py27-django110
   - TOXENV=py27-django_trunk
-  - TOXENV=py33-django15
-  - TOXENV=py33-django16
-  - TOXENV=py33-django17
   - TOXENV=py33-django18
-  - TOXENV=py34-django110
-  - TOXENV=py34-django17
   - TOXENV=py34-django18
   - TOXENV=py34-django19
+  - TOXENV=py34-django110
   - TOXENV=py34-django_trunk
-  - TOXENV=py35-django110
   - TOXENV=py35-django18
   - TOXENV=py35-django19
+  - TOXENV=py35-django110
   - TOXENV=py35-django_trunk
 
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ CHANGES
 master (unreleased)
 -------------------
 
+* Drop support for Python 2.6.
+
+* Drop support for Django 1.4, 1.5, 1.6, 1.7.
+
+
 2.6.1 (2017.01.11)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,8 @@ django-model-utils
 
 Django model mixins and utilities.
 
-``django-model-utils`` supports `Django`_ 1.4 through 1.9 (latest bugfix
-release in each series only) on Python 2.6 (through Django 1.6 only), 2.7, 3.3
-(through Django 1.8 only), 3.4 and 3.5.
+``django-model-utils`` supports `Django`_ 1.8 through 1.10 (latest bugfix
+release in each series only) on Python 2.7, 3.3 (Django 1.8 only), 3.4 and 3.5.
 
 .. _Django: http://www.djangoproject.com/
 

--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -84,14 +84,7 @@ If you don't explicitly call ``select_subclasses()`` or ``get_subclass()``,
 an ``InheritanceManager`` behaves identically to a normal ``Manager``; so
 it's safe to use as your default manager for the model.
 
-.. note::
-
-    Due to `Django bug #16572`_, on Django versions prior to 1.6
-    ``InheritanceManager`` only supports a single level of model inheritance;
-    it won't work for grandchild models.
-
 .. _contributed by Jeff Elmore: http://jeffelmore.org/2010/11/11/automatic-downcasting-of-inherited-models-in-django/
-.. _Django bug #16572: https://code.djangoproject.com/ticket/16572
 
 
 .. _QueryManager:

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -17,7 +17,7 @@ modify your ``INSTALLED_APPS`` setting.
 Dependencies
 ============
 
-``django-model-utils`` supports `Django`_ 1.4.2 and later on Python 2.6, 2.7,
-3.2, and 3.3.
+``django-model-utils`` supports `Django`_ 1.8 through 1.10 (latest bugfix
+release in each series only) on Python 2.7, 3.3 (Django 1.8 only), 3.4 and 3.5.
 
 .. _Django: http://www.djangoproject.com/

--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -241,30 +241,3 @@ class SplitField(models.TextField):
         name, path, args, kwargs = super(SplitField, self).deconstruct()
         kwargs['no_excerpt_field'] = True
         return name, path, args, kwargs
-
-# allow South to handle these fields smoothly
-try:
-    from south.modelsinspector import add_introspection_rules
-    # For a normal MarkupField, the add_excerpt_field attribute is
-    # always True, which means no_excerpt_field arg will always be
-    # True in a frozen MarkupField, which is what we want.
-    add_introspection_rules(rules=[
-        (
-            (SplitField,),
-            [],
-            {'no_excerpt_field': ('add_excerpt_field', {})}
-        ),
-        (
-            (MonitorField,),
-            [],
-            {'monitor': ('monitor', {})}
-        ),
-        (
-            (StatusField,),
-            [],
-            {'no_check_for_status': ('check_for_status', {})}
-        ),
-    ], patterns=['model_utils\.fields\.'])
-except ImportError:
-    pass
-

--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -228,7 +228,7 @@ class SplitField(models.TextField):
         return value.content
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return value.content
 
     def get_prep_value(self, value):

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -5,12 +5,8 @@ from django.db.models.fields.related import OneToOneField, OneToOneRel
 from django.db.models.query import QuerySet
 from django.core.exceptions import ObjectDoesNotExist
 
-try:
-    from django.db.models.constants import LOOKUP_SEP
-    from django.utils.six import string_types
-except ImportError:  # Django < 1.5
-    from django.db.models.sql.constants import LOOKUP_SEP
-    string_types = (basestring,)
+from django.db.models.constants import LOOKUP_SEP
+from django.utils.six import string_types
 
 
 class InheritanceQuerySetMixin(object):

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -139,10 +139,10 @@ class InheritanceQuerySetMixin(object):
         if levels:
             levels -= 1
         while parent_link is not None:
-            if django.VERSION < (1, 8):
-                related = parent_link.related
-            else:
+            if django.VERSION < (1, 9):
                 related = parent_link.rel
+            else:
+                related = parent_link.remote_field
             ancestry.insert(0, related.get_accessor_name())
             if levels or levels is None:
                 if django.VERSION < (1, 8):

--- a/model_utils/tests/helpers.py
+++ b/model_utils/tests/helpers.py
@@ -1,5 +1,0 @@
-
-try:
-    from unittest import skipUnless
-except ImportError: # Python 2.6
-    from django.utils.unittest import skipUnless

--- a/model_utils/tests/models.py
+++ b/model_utils/tests/models.py
@@ -28,9 +28,12 @@ class InheritanceManagerTestParent(models.Model):
     # FileField is just a handy descriptor-using field. Refs #6.
     non_related_field_using_descriptor = models.FileField(upload_to="test")
     related = models.ForeignKey(
-        InheritanceManagerTestRelated, related_name="imtests", null=True)
+        InheritanceManagerTestRelated, related_name="imtests", null=True,
+        on_delete=models.CASCADE)
     normal_field = models.TextField()
-    related_self = models.OneToOneField("self", related_name="imtests_self", null=True)
+    related_self = models.OneToOneField(
+        "self", related_name="imtests_self", null=True,
+        on_delete=models.CASCADE)
     objects = InheritanceManager()
 
     def __unicode__(self):
@@ -65,7 +68,7 @@ class InheritanceManagerTestChild2(InheritanceManagerTestParent):
 class InheritanceManagerTestChild3(InheritanceManagerTestParent):
     parent_ptr = models.OneToOneField(
         InheritanceManagerTestParent, related_name='manual_onetoone',
-        parent_link=True)
+        parent_link=True, on_delete=models.CASCADE)
 
 
 class TimeStamp(TimeStampedModel):
@@ -219,7 +222,7 @@ class Tracked(models.Model):
 
 
 class TrackedFK(models.Model):
-    fk = models.ForeignKey('Tracked')
+    fk = models.ForeignKey('Tracked', on_delete=models.CASCADE)
 
     tracker = FieldTracker()
     custom_tracker = FieldTracker(fields=['fk_id'])
@@ -275,7 +278,7 @@ class ModelTracked(models.Model):
 
 
 class ModelTrackedFK(models.Model):
-    fk = models.ForeignKey('ModelTracked')
+    fk = models.ForeignKey('ModelTracked', on_delete=models.CASCADE)
 
     tracker = ModelTracker()
     custom_tracker = ModelTracker(fields=['fk_id'])

--- a/model_utils/tests/test_fields/__init__.py
+++ b/model_utils/tests/test_fields/__init__.py
@@ -1,5 +1,0 @@
-# Needed for Django 1.4/1.5 test runner
-from .test_field_tracker import *
-from .test_monitor_field import *
-from .test_split_field import *
-from .test_status_field import *

--- a/model_utils/tests/test_fields/test_field_tracker.py
+++ b/model_utils/tests/test_fields/test_field_tracker.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
+from unittest import skipUnless
+
 import django
 from django.core.exceptions import FieldError
 from django.test import TestCase
 
 from model_utils import FieldTracker
-from model_utils.tests.helpers import skipUnless
 from model_utils.tests.models import (
     Tracked, TrackedFK, InheritedTrackedFK, TrackedNotDefault, TrackedNonFieldAttr, TrackedMultiple,
     InheritedTracked, TrackedFileField,
@@ -97,15 +98,14 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
         self.assertPrevious(name=None, number=None, mutable=None)
         self.assertCurrent(name='retro', number=4, id=None, mutable=[1,2,3])
         self.assertChanged(name=None, number=None, mutable=None)
-        # Django 1.4 doesn't have update_fields
-        if django.VERSION >= (1, 5, 0):
-            self.instance.save(update_fields=[])
-            self.assertHasChanged(name=True, number=True, mutable=True)
-            self.assertPrevious(name=None, number=None, mutable=None)
-            self.assertCurrent(name='retro', number=4, id=None, mutable=[1,2,3])
-            self.assertChanged(name=None, number=None, mutable=None)
-            with self.assertRaises(ValueError):
-                self.instance.save(update_fields=['number'])
+
+        self.instance.save(update_fields=[])
+        self.assertHasChanged(name=True, number=True, mutable=True)
+        self.assertPrevious(name=None, number=None, mutable=None)
+        self.assertCurrent(name='retro', number=4, id=None, mutable=[1,2,3])
+        self.assertChanged(name=None, number=None, mutable=None)
+        with self.assertRaises(ValueError):
+            self.instance.save(update_fields=['number'])
 
     def test_post_save_has_changed(self):
         self.update_instance(name='retro', number=4, mutable=[1,2,3])
@@ -153,8 +153,6 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
         self.instance.save()
         self.assertCurrent(id=self.instance.id, name='new age', number=8, mutable=[1,4,3])
 
-    @skipUnless(
-        django.VERSION >= (1, 5, 0), "Django 1.4 doesn't have update_fields")
     def test_update_fields(self):
         self.update_instance(name='retro', number=4, mutable=[1,2,3])
         self.assertChanged()
@@ -280,8 +278,6 @@ class FieldTrackedModelCustomTests(FieldTrackerTestCase,
         self.instance.save()
         self.assertCurrent(name='new age')
 
-    @skipUnless(
-        django.VERSION >= (1, 5, 0), "Django 1.4 doesn't have update_fields")
     def test_update_fields(self):
         self.update_instance(name='retro', number=4)
         self.assertChanged()
@@ -622,15 +618,14 @@ class ModelTrackerTests(FieldTrackerTests):
         self.assertPrevious(name=None, number=None, mutable=None)
         self.assertCurrent(name='retro', number=4, id=None, mutable=[1,2,3])
         self.assertChanged()
-        # Django 1.4 doesn't have update_fields
-        if django.VERSION >= (1, 5, 0):
-            self.instance.save(update_fields=[])
-            self.assertHasChanged(name=True, number=True, mutable=True)
-            self.assertPrevious(name=None, number=None, mutable=None)
-            self.assertCurrent(name='retro', number=4, id=None, mutable=[1,2,3])
-            self.assertChanged()
-            with self.assertRaises(ValueError):
-                self.instance.save(update_fields=['number'])
+
+        self.instance.save(update_fields=[])
+        self.assertHasChanged(name=True, number=True, mutable=True)
+        self.assertPrevious(name=None, number=None, mutable=None)
+        self.assertCurrent(name='retro', number=4, id=None, mutable=[1,2,3])
+        self.assertChanged()
+        with self.assertRaises(ValueError):
+            self.instance.save(update_fields=['number'])
 
     def test_pre_save_has_changed(self):
         self.assertHasChanged(name=True, number=True)

--- a/model_utils/tests/test_managers/__init__.py
+++ b/model_utils/tests/test_managers/__init__.py
@@ -1,5 +1,0 @@
-# Needed for Django 1.4/1.5 test runner
-from .test_inheritance_manager import *
-from .test_query_manager import *
-from .test_status_manager import *
-from .test_softdelete_manager import *

--- a/model_utils/tests/test_managers/test_inheritance_manager.py
+++ b/model_utils/tests/test_managers/test_inheritance_manager.py
@@ -1,10 +1,11 @@
 from __future__ import unicode_literals
 
+from unittest import skipUnless
+
 import django
 from django.db import models
 from django.test import TestCase
 
-from model_utils.tests.helpers import skipUnless
 from model_utils.tests.models import (InheritanceManagerTestRelated, InheritanceManagerTestGrandChild1,
                                       InheritanceManagerTestGrandChild1_2, InheritanceManagerTestParent,
                                       InheritanceManagerTestChild1,
@@ -34,12 +35,8 @@ class InheritanceManagerTests(TestCase):
 
     def test_select_all_subclasses(self):
         children = set([self.child1, self.child2])
-        if django.VERSION >= (1, 6, 0):
-            children.add(self.grandchild1)
-            children.add(self.grandchild1_2)
-        else:
-            children.add(InheritanceManagerTestChild1(pk=self.grandchild1.pk))
-            children.add(InheritanceManagerTestChild1(pk=self.grandchild1_2.pk))
+        children.add(self.grandchild1)
+        children.add(self.grandchild1_2)
         self.assertEqual(
             set(self.get_manager().select_subclasses()), children)
 
@@ -68,7 +65,6 @@ class InheritanceManagerTests(TestCase):
             children,
         )
 
-    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
     def test_select_specific_grandchildren(self):
         children = set([
             InheritanceManagerTestParent(pk=self.child1.pk),
@@ -85,7 +81,6 @@ class InheritanceManagerTests(TestCase):
             children,
         )
 
-    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
     def test_children_and_grandchildren(self):
         children = set([
             self.child1,
@@ -120,39 +115,9 @@ class InheritanceManagerTests(TestCase):
                 "inheritancemanagertestchild2").get(pk=self.child1.pk)
             obj.inheritancemanagertestchild1
 
-    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
     def test_version_determining_any_depth(self):
         self.assertIsNone(self.get_manager().all()._get_maximum_depth())
 
-    @skipUnless(django.VERSION < (1, 6, 0), "test only applies to Django < 1.6")
-    def test_version_determining_only_child_depth(self):
-        self.assertEqual(1, self.get_manager().all()._get_maximum_depth())
-
-    @skipUnless(django.VERSION < (1, 6, 0), "test only applies to Django < 1.6")
-    def test_manually_specifying_parent_fk_only_children(self):
-        """
-        given a Model which inherits from another Model, but also declares
-        the OneToOne link manually using `related_name` and `parent_link`,
-        ensure that the relation names and subclasses are obtained correctly.
-        """
-        child3 = InheritanceManagerTestChild3.objects.create()
-        results = InheritanceManagerTestParent.objects.all().select_subclasses()
-
-        expected_objs = [self.child1, self.child2,
-                         InheritanceManagerTestChild1(pk=self.grandchild1.pk),
-                         InheritanceManagerTestChild1(pk=self.grandchild1_2.pk),
-                         child3]
-        self.assertEqual(list(results), expected_objs)
-
-        expected_related_names = [
-            'inheritancemanagertestchild1',
-            'inheritancemanagertestchild2',
-            'manual_onetoone',  # this was set via parent_link & related_name
-        ]
-        self.assertEqual(set(results.subclasses),
-                         set(expected_related_names))
-
-    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
     def test_manually_specifying_parent_fk_including_grandchildren(self):
         """
         given a Model which inherits from another Model, but also declares
@@ -267,7 +232,6 @@ class InheritanceManagerUsingModelsTests(TestCase):
         self.assertEqual(objs.subclasses, objsmodels.subclasses)
         self.assertEqual(list(objs), list(objsmodels))
 
-    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
     def test_select_subclass_by_grandchild_model(self):
         """
         Confirm that passing a grandchild model works the same as passing the
@@ -281,7 +245,6 @@ class InheritanceManagerUsingModelsTests(TestCase):
         self.assertEqual(objs.subclasses, objsmodels.subclasses)
         self.assertEqual(list(objs), list(objsmodels))
 
-    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
     def test_selecting_all_subclasses_specifically_grandchildren(self):
         """
         A bare select_subclasses() should achieve the same results as doing
@@ -310,16 +273,11 @@ class InheritanceManagerUsingModelsTests(TestCase):
         """
         objs = InheritanceManagerTestParent.objects.select_subclasses().order_by('pk')
 
-        if django.VERSION >= (1, 6, 0):
-            models = (InheritanceManagerTestChild1,
-                      InheritanceManagerTestChild2,
-                      InheritanceManagerTestChild3,
-                      InheritanceManagerTestGrandChild1,
-                      InheritanceManagerTestGrandChild1_2)
-        else:
-            models = (InheritanceManagerTestChild1,
-                      InheritanceManagerTestChild2,
-                      InheritanceManagerTestChild3)
+        models = (InheritanceManagerTestChild1,
+                  InheritanceManagerTestChild2,
+                  InheritanceManagerTestChild3,
+                  InheritanceManagerTestGrandChild1,
+                  InheritanceManagerTestGrandChild1_2)
 
         objsmodels = InheritanceManagerTestParent.objects.select_subclasses(
             *models).order_by('pk')
@@ -353,7 +311,6 @@ class InheritanceManagerUsingModelsTests(TestCase):
             InheritanceManagerTestParent.objects.select_subclasses(
                 TimeFrame).order_by('pk')
 
-    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
     def test_mixing_strings_and_classes_with_grandchildren(self):
         """
         Given arguments consisting of both strings and model classes,
@@ -414,7 +371,6 @@ class InheritanceManagerUsingModelsTests(TestCase):
             InheritanceManagerTestParent(pk=self.grandchild1_2.pk),
         ])
 
-    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
     def test_child_doesnt_accidentally_get_parent(self):
         """
         Given a Child model which also has an InheritanceManager,

--- a/model_utils/tests/test_miscellaneous.py
+++ b/model_utils/tests/test_miscellaneous.py
@@ -1,20 +1,12 @@
 from __future__ import unicode_literals
 
-import django
-from django.db.models.fields import FieldDoesNotExist
 from django.core.management import call_command
 from django.test import TestCase
 
 from model_utils.fields import get_excerpt
-from model_utils.tests.models import (
-    Article,
-    StatusFieldDefaultFilled,
-)
-from model_utils.tests.helpers import skipUnless
 
 
 class MigrationsTests(TestCase):
-    @skipUnless(django.VERSION >= (1, 7, 0), "test only applies to Django 1.7+")
     def test_makemigrations(self):
         call_command('makemigrations', dry_run=True)
 
@@ -35,26 +27,3 @@ class GetExcerptTests(TestCase):
     def test_middle_of_line(self):
         e = get_excerpt("some text <!-- split --> more text")
         self.assertEqual(e, "some text <!-- split --> more text")
-
-try:
-    from south.modelsinspector import introspector
-except ImportError:
-    introspector = None
-
-
-@skipUnless(introspector, 'South is not installed')
-class SouthFreezingTests(TestCase):
-    def test_introspector_adds_no_excerpt_field(self):
-        mf = Article._meta.get_field('body')
-        args, kwargs = introspector(mf)
-        self.assertEqual(kwargs['no_excerpt_field'], 'True')
-
-    def test_no_excerpt_field_works(self):
-        from .models import NoRendered
-        with self.assertRaises(FieldDoesNotExist):
-            NoRendered._meta.get_field('_body_excerpt')
-
-    def test_status_field_no_check_for_status(self):
-        sf = StatusFieldDefaultFilled._meta.get_field('status')
-        args, kwargs = introspector(sf)
-        self.assertEqual(kwargs['no_check_for_status'], 'True')

--- a/model_utils/tests/test_models/__init__.py
+++ b/model_utils/tests/test_models/__init__.py
@@ -1,5 +1,0 @@
-# Needed for Django 1.4/1.5 test runner
-from .test_softdeletable_model import *
-from .test_status_model import *
-from .test_timeframed_model import *
-from .test_timestamped_model import *

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -1,9 +1,0 @@
-import django
-
-# Needed for Django 1.4/1.5 test runner
-if django.VERSION < (1, 6):
-    from .test_fields import *
-    from .test_managers import *
-    from .test_models import *
-    from .test_choices import *
-    from .test_miscellaneous import *

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email='carl@oddbird.net',
     url='https://github.com/carljm/django-model-utils/',
     packages=find_packages(),
-    install_requires=['Django>=1.4.2'],
+    install_requires=['Django>=1.8'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
@@ -47,7 +47,7 @@ setup(
         'Framework :: Django',
     ],
     zip_safe=False,
-    tests_require=["Django>=1.4.2"],
+    tests_require=['Django>=1.8'],
     test_suite='runtests.runtests',
     package_data={
         'model_utils': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
 envlist =
-    py26-django{14,15,16},
-    py27-django{14,19,110,_trunk}, py27-django15_nosouth,
-    py{27,33}-django{15,16,17,18},
-    py34-django{17,18,19,110,_trunk},
+    py27-django{18,19,110,_trunk},
+    py33-django{18},
+    py34-django{18,19,110,_trunk},
     py35-django{18,19,110,_trunk},
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py33: python3.3
     py34: python3.4
@@ -16,15 +14,10 @@ basepython =
 
 deps =
     coverage == 3.6
-    django14: Django>=1.4,<1.5
-    django15{,_nosouth}: Django>=1.5,<1.6
-    django16: Django>=1.6,<1.7
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django_trunk: https://github.com/django/django/tarball/master
-    django{14,15,16}: South==1.0.2
     freezegun == 0.3.8
 
 commands = coverage run -a setup.py test


### PR DESCRIPTION
- Drops support for anything below Django 1.8 (current LTS release)
- ~~Cleans up some pep8 E303 warnings. I can remove this commit - just went ahead because my editor lit up like a christmas tree.~~
- ~~Resolves 183~~.
- Supersedes / closes #162.
- Supersedes / closes #204.
