### PR TITLE
Fixed a bug with Django >= 1.9 and values_list being called on InheritanceQuerySet

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,6 +2,7 @@ ad-m <github.com/ad-m>
 Alejandro Varas <alej0varas@gmail.com>
 Alex Orange <crazycasta@gmail.com>
 Andy Freeland <andy@andyfreeland.net>
+Artis Avotins <artis.avotins@gmail.com>
 Bram Boogaard <b.boogaard@auto-interactive.nl>
 Carl Meyer <carl@dirtcircle.com>
 Curtis Maloney <curtis@tinbrain.net>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ CHANGES
 master (unreleased)
 -------------------
 
+* Fix `InheritanceQuerySet` raising an `AttributeError` exception
+  under Django 1.9.
+
 
 2.5 (2016-04-18)
 ----------------

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -161,6 +161,12 @@ class InheritanceQuerySetMixin(object):
 
     def _get_sub_obj_recurse(self, obj, s):
         rel, _, s = s.partition(LOOKUP_SEP)
+
+        # Django 1.9: If a primitive type gets passed to this recursive function,
+        # return None as non-models are not part of inheritance.
+        if not isinstance(obj, models.Model):
+            return None
+
         try:
             node = getattr(obj, rel)
         except ObjectDoesNotExist:


### PR DESCRIPTION
After upgrading an application to Django 1.9 that uses django-model-utils for polymorphic models, I encountered a bug:

Whenever `values_list` was called on an InheritanceQuerySet, `AttributeError` would be raised complaining about either `tuple`(in case of `flat` parameter being false) or `integer`(or any other primitive variable type that's defined for the model and used in `values_list`) in case of `flat` being true, not having an attribute of `insert_child_model_name_here`.

This is a bugfix for that, which adds type checking to `_get_sub_obj_recurse` function.

I also added a new test case `test_dj19_values_list_on_select_subclasses`, that exercises this bug.

Fastest way to reproduce:

- Check out this branch
- Comment out my changes in managers.py L165:168
- Run test cases