### PR TITLE
1.10 fix

### DIFF
--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -63,7 +63,7 @@ class FieldInstanceTracker(object):
 
     def init_deferred_fields(self):
         self.instance._deferred_fields = []
-        if not self.instance._deferred:
+        if hasattr(self.instance, '_deferred') and not self.instance._deferred:
             return
 
         class DeferredAttributeTracker(DeferredAttribute):


### PR DESCRIPTION
```python
  File "/usr/local/lib/python2.7/dist-packages/model_utils/tracker.py", line 15, in __init__
    self.init_deferred_fields()
  File "/usr/local/lib/python2.7/dist-packages/model_utils/tracker.py", line 66, in init_deferred_fields
    if hasattr(self.instance, '_deferred') and not self.instance._deferred:
AttributeError: 'Output' object has no attribute '_deferred'
```