### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ This app is available on `PyPI`_.
 Getting Help
 ============
 
-Documentation for django-model-utils is available at https://django-model-utils.readthedocs.org/
+Documentation for django-model-utils is available at https://django-model-utils.readthedocs.io/
 
 
 Contributing


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.