### PR TITLE
Support Django 1.10 deferred FileField with FieldTracker

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,6 +1,7 @@
 ad-m <github.com/ad-m>
 Alejandro Varas <alej0varas@gmail.com>
 Alex Orange <crazycasta@gmail.com>
+Alexey Evseev <myhappydo@gmail.com>
 Andy Freeland <andy@andyfreeland.net>
 Artis Avotins <artis.avotins@gmail.com>
 Bram Boogaard <b.boogaard@auto-interactive.nl>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ CHANGES
 master (unreleased)
 -------------------
 
+* Fix issue with field tracker and deferred FileField for Django 1.10.
+
 
 2.5.2 (2016.08.09)
 ------------------

--- a/model_utils/tests/models.py
+++ b/model_utils/tests/models.py
@@ -242,6 +242,12 @@ class TrackedMultiple(models.Model):
     number_tracker = FieldTracker(fields=['number'])
 
 
+class TrackedFileField(models.Model):
+    some_file = models.FileField(upload_to='test_location')
+
+    tracker = FieldTracker()
+
+
 class InheritedTracked(Tracked):
     name2 = models.CharField(max_length=20)
 
@@ -280,6 +286,7 @@ class ModelTrackedMultiple(models.Model):
 
     name_tracker = ModelTracker(fields=['name'])
     number_tracker = ModelTracker(fields=['number'])
+
 
 class InheritedModelTracked(ModelTracked):
     name2 = models.CharField(max_length=20)


### PR DESCRIPTION
For deferred `FileField` Django 1.10 returns `FileDescriptor`, not a `DeferredAttribute`.
As a result, code

    class MyModel(models.Model):
        some_file = models.FileField(upload_to='test_location')

        tracker = FieldTracker()


    obj = MyModel.objects.defer('some_file')[0]
    obj.tracker.changed()

raises exception like this:

    Traceback (most recent call last):
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/model_utils/tests/tests.py", line 1808, in test_post_save_previous
        deferred_instance = self.tracked_class.objects.defer('some_file')[0]
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/.tox/py27-django110/lib/python2.7/site-packages/django/db/models/query.py", line 295, in __getitem__
        return list(qs)[0]
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/.tox/py27-django110/lib/python2.7/site-packages/django/db/models/query.py", line 256, in __iter__
        self._fetch_all()
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/.tox/py27-django110/lib/python2.7/site-packages/django/db/models/query.py", line 1087, in _fetch_all
        self._result_cache = list(self.iterator())
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/.tox/py27-django110/lib/python2.7/site-packages/django/db/models/query.py", line 66, in __iter__
        obj = model_cls.from_db(db, init_list, row[model_fields_start:model_fields_end])
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/.tox/py27-django110/lib/python2.7/site-packages/django/db/models/base.py", line 565, in from_db
        new = cls(*values)
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/.tox/py27-django110/lib/python2.7/site-packages/django/db/models/base.py", line 557, in __init__
        signals.post_init.send(sender=self.__class__, instance=self)
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/.tox/py27-django110/lib/python2.7/site-packages/django/dispatch/dispatcher.py", line 191, in send
        response = receiver(signal=self, sender=sender, **named)
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/model_utils/tracker.py", line 141, in initialize_tracker
        tracker = self.tracker_class(instance, self.fields, self.field_map)
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/model_utils/tracker.py", line 16, in __init__
        self.init_deferred_fields()
      File "/Users/stalk/develop/libs/django-model-utils/django-model-utils/model_utils/tracker.py", line 90, in init_deferred_fields
        field_obj.field_name, None)
    AttributeError: 'FileDescriptor' object has no attribute 'field_name'

This patch tends to fix it.

