### PR TITLE
Update tests to use freezegun to avoid time resolution issues on Windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,5 +25,6 @@ deps =
     django110: Django>=1.10,<1.11
     django_trunk: https://github.com/django/django/tarball/master
     django{14,15,16}: South==1.0.2
+    freezegun == 0.3.8
 
 commands = coverage run -a setup.py test


### PR DESCRIPTION
Solution proposed to fix #206 

On a general way, we should use `freezegun` if we want to test anything related to values generated with `now()`.