### PR TITLE
Update changelog about 2 recent pull requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ master (unreleased)
   GH-250, fixes GH-249.
 * Add mixins for `SoftDeletableQuerySet` and `SoftDeletableManager`, as stated
   in the the documentation.
+* Fix `SoftDeletableModel.delete()` to use the correct database connection.
+  Merge of GH-239.
+* Added boolean keyword argument `soft` to `SoftDeletableModel.delete()` that
+  revert to default behavior when set to `False`. Merge of GH-240.
 
 
 2.6 (2016.09.19)


### PR DESCRIPTION
2 pull requests - #239 and #240 - I've submitted recently aren't mentioned at the top of the changelog. Adding them [to minimise the effort](http://keepachangelog.com/) required when the next release will be done.

On a related note, what do you think of adding a [pull request template](https://github.com/blog/2111-issue-and-pull-request-templates) with a checklist? One of the items could be to add an entry at the top of the changelog.