### PR TITLE
Pull request and issue template fixes #254

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Problem
+
+Explain the problem you encountered.
+
+## Environment
+
+- Django Model Utils version:
+- Django version: 
+- Python version: 
+- Other libraries used, if any:
+
+## Code examples
+
+Give code example that demonstrates the issue, or even better, write new tests that fails because of that issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Problem
+
+Explain the problem you are fixing (add the link to the related issue(s), if any).
+
+## Solution
+
+Explain the solution that has been implemented, and what has been changed.
+
+## Commandments
+
+- [ ] Write PEP8 compliant code.
+- [ ] Cover it with tests.
+- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
+- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
+- [ ] Update documentation (if relevant).


### PR DESCRIPTION
## Problem

Fixes #254

## Solution

Adding Issue and Pull Request templates into `.github/` folder.

## Commandments

- [x] Write PEP8 compliant code (N/A)
- [x] Cover it with tests (N/A)
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`
- [x] Pay attention to backward compatibility, or if it breaks it, explain why
- [x] Update documentation (N/A).