### PR TITLE
Remove compatibility code in runtests.py file

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -24,21 +24,14 @@ def runtests():
     if not settings.configured:
         settings.configure(**DEFAULT_SETTINGS)
 
-    # Compatibility with Django 1.7's stricter initialization
-    if hasattr(django, 'setup'):
-        django.setup()
+    django.setup()
 
     parent = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, parent)
 
-    try:
-        from django.test.runner import DiscoverRunner
-        runner_class = DiscoverRunner
-        test_args = ['model_utils.tests']
-    except ImportError:
-        from django.test.simple import DjangoTestSuiteRunner
-        runner_class = DjangoTestSuiteRunner
-        test_args = ['tests']
+    from django.test.runner import DiscoverRunner
+    runner_class = DiscoverRunner
+    test_args = ['model_utils.tests']
 
     failures = runner_class(
         verbosity=1, interactive=True, failfast=False).run_tests(test_args)


### PR DESCRIPTION
## Problem

Some remaining compatibility code is remaining in `runtests.py` after #212 big cleaning.

## Solution

Remove this compatibility code, as it is no more needed.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
