### PR TITLE
Add "license" arg to setup() call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ def get_version(root_path):
 setup(
     name='django-model-utils',
     version=get_version(HERE),
+    license="BSD",
     description='Django model mixins and utilities',
     long_description=long_description,
     author='Carl Meyer',


### PR DESCRIPTION
## Problem

Services such as https://pyup.io grab license info from package metadata to display alongside each requirement. django-model-utils isn't providing that license info in it's metadata.

## Solution

Add a ``license`` argument to the ``setup()`` call in setup.py

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
