### PR TITLE
Support django 1.11 iterator changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ master (unreleased)
 * Drop support for Python 2.6.
 * Drop support for Django 1.4, 1.5, 1.6, 1.7.
 * Exclude tests from the distribution, fixes GH-258.
+* Add support for Django 1.11 GH-269
 
 
 2.6.1 (2017.01.11)


### PR DESCRIPTION
Django starting with 1.9 switched to using a class to provide an
iterator for the querymanager.  Between 1.9 and 1.10 changes slowly
stopped referencing that function and instead started calling
_iterator_class directly.

As the functionality model-utils is patching has moved, this patch moves
the iterator logic to a class to match the changes that have been made
in Django in version 1.9.

As Django 1.8 is a LTS release that is still supported, iterator()
is retained in the InheritanceQuerySetMixin and can be removed when
support for Django 1.8 is removed.  This goes for the try-except in the
import statements as well.